### PR TITLE
Dev Docs: Tweak GetHashesPerSec Deprecation

### DIFF
--- a/_autocrossref.yaml
+++ b/_autocrossref.yaml
@@ -544,3 +544,4 @@ Bitcoin Core 0.9.0:
 Bitcoin Core 0.9.1:
 Bitcoin Core 0.9.3:
 Bitcoin Core 0.10.0:
+Bitcoin Core master:

--- a/_includes/helpers/summaries.md
+++ b/_includes/helpers/summaries.md
@@ -27,7 +27,7 @@ This file is licensed under the terms of its source texts{%endcomment%}
 {% assign summary_getConnectionCount="returns the number of connections to other nodes." %}
 {% assign summary_getDifficultly="returns the proof-of-work difficulty as a multiple of the minimum difficulty." %}
 {% assign summary_getGenerate="returns true if the node is set to generate blocks using its CPU." %}
-{% assign summary_getHashesPerSec="returns a recent hashes per second performance measurement when the node is generating blocks." %}
+{% assign summary_getHashesPerSec="was removed in Bitcoin Core master (unreleased). It returned a recent hashes per second performance measurement when the node was generating blocks." %}
 {% assign summary_getInfo="prints various information about the node and the network." %}
 {% assign summary_getMemPoolInfo="returns information about the node's current transaction memory pool." %}
 {% assign summary_getMiningInfo="returns various mining-related information." %}

--- a/_includes/ref/bitcoin-core/rpcs/quick-ref.md
+++ b/_includes/ref/bitcoin-core/rpcs/quick-ref.md
@@ -16,6 +16,9 @@ changes made more than two years ago.
 Use v0.n.n in abbreviation title to prevent autocrossrefing.
 {% endcomment %}
 
+<!-- master -->
+{% assign UPDATED_MASTER='**<abbr title="Updated in Bitcoin Core’s master branch (unreleased)">Updated in master</abbr>**' %}
+
 <!-- Bitcoin Core 0.10.0 expected January 2015 -->
 {% assign DEPRECATED='**<abbr title="Deprecated; will be removed in a future version of Bitcoin Core">Deprecated</abbr>**' %}
 {% assign NEW0_10_0='**<abbr title="New in Bitcoin Core v0.10.0">New in 0.10.0</abbr>**' %}
@@ -74,7 +77,6 @@ Use v0.n.n in abbreviation title to prevent autocrossrefing.
 {% autocrossref %}
 
 * [GetGenerate][rpc getgenerate]: {{summary_getGenerate}}
-* [GetHashesPerSec][rpc gethashespersec]: {{summary_getHashesPerSec}}
 * [SetGenerate][rpc setgenerate]: {{summary_setGenerate}}
 
 {% endautocrossref %}
@@ -86,7 +88,7 @@ Use v0.n.n in abbreviation title to prevent autocrossrefing.
 {% autocrossref %}
 
 * [GetBlockTemplate][rpc getblocktemplate]: {{summary_getBlockTemplate}}
-* [GetMiningInfo][rpc getmininginfo]: {{summary_getMiningInfo}}
+* [GetMiningInfo][rpc getmininginfo]: {{summary_getMiningInfo}} {{UPDATED_MASTER}}
 * [GetNetworkHashPS][rpc getnetworkhashps]: {{summary_getNetworkHashPS}}
 * [PrioritiseTransaction][rpc prioritisetransaction]: {{summary_prioritiseTransaction}} {{NEW0_10_0}}
 * [SubmitBlock][rpc submitblock]: {{summary_submitBlock}}
@@ -196,7 +198,7 @@ default.
 
 {% autocrossref %}
 
-* [GetWork][rpc getwork]: {{summary_getWork}} {{REMOVED0_10_0}}
-* [GetHashesPerSec][rpc gethashespersec]: {{summary_getHashesPerSec}} {{REMOVED0_10_0}}
+* [GetHashesPerSec][rpc gethashespersec]: {{summary_getHashesPerSec}}
+* [GetWork][rpc getwork]: {{summary_getWork}}
 
 {% endautocrossref %}

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/gethashespersec.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/gethashespersec.md
@@ -7,7 +7,7 @@ http://opensource.org/licenses/MIT.
 ##### GetHashesPerSec
 {% include helpers/subhead-links.md %}
 
-{% assign summary_getHashesPerSec="was removed in Bitcoin Core 0.10.0. It returned a recent hashes per second performance measurement when the node was generating blocks." %}
+{% assign summary_getHashesPerSec="was removed in Bitcoin Core master (unreleased). It returned a recent hashes per second performance measurement when the node was generating blocks." %}
 
 {% autocrossref %}
 
@@ -24,7 +24,7 @@ The `gethashespersec` RPC {{summary_getHashesPerSec}}
 | `result`           | number (int)    | Required<br>(exactly 1)     | If generation is enabled, the number of hashes per second your computer most recently generated.  If generation is disabled, the value `0`
 {:.ntpd}
 
-*Example from Bitcoin Core 0.9.3*
+*Example from Bitcoin Core 0.10.0*
 
 {% highlight bash %}
 bitcoin-cli -testnet gethashespersec

--- a/_includes/ref/bitcoin-core/rpcs/rpcs/getmininginfo.md
+++ b/_includes/ref/bitcoin-core/rpcs/rpcs/getmininginfo.md
@@ -31,7 +31,7 @@ The `getmininginfo` RPC {{summary_getMiningInfo}}
 | →<br>`testnet`          | bool              | Required<br>(exactly 1)     | Set to `true` if this node is running on testnet.  Set to `false` if this node is on mainnet or a regtest
 | →<br>`chain`            | string            | Required<br>(exactly 1)     | Set to `main` for mainnet, `test` for testnet, and `regtest` for regtest
 | →<br>`generate`         | bool              | Optional<br>(0 or 1)        | Set to `true` if generation is currently enabled; set to `false` if generation is currently disabled.  Only returned if the node has wallet support enabled
-| →<br>`hashespersec`     | number (int)      | Optional<br>(0 or 1)        | The approximate number of hashes per second this node is generating across all CPUs, if generation is enabled.  Otherwise `0`.  Only returned if the node has wallet support enabled
+| →<br>`hashespersec`     | number (int)      | Optional<br>(0 or 1)        | *Removed in Bitcoin Core master (unreleased)*<br><br>The approximate number of hashes per second this node is generating across all CPUs, if generation is enabled.  Otherwise `0`.  Only returned if the node has wallet support enabled
 {:.ntpd}
 
 *Example from Bitcoin Core 0.10.0*

--- a/_includes/references.md
+++ b/_includes/references.md
@@ -386,6 +386,7 @@ http://opensource.org/licenses/MIT.
 [Bitcoin Core 0.3.18]: https://github.com/bitcoin/bitcoin/commit/82201801336f64ee77851b9eaab9383ee4e442f0
 [bitcoin core fee drop commit]: https://github.com/bitcoin/bitcoin/commit/6a4c196dd64da2fd33dc7ae77a8cdd3e4cf0eff1
 [Bitcoin Core issue #2381]: https://github.com/bitcoin/bitcoin/issues/2381
+[Bitcoin Core master]: https://github.com/bitcoin/bitcoin
 [Bitcoin Core pull #4468]: https://github.com/bitcoin/bitcoin/pull/4468
 [Bitcoin Seeder]: https://github.com/sipa/bitcoin-seeder
 [bitcoin-documentation mailing list]: https://groups.google.com/forum/#!forum/bitcoin-documentation


### PR DESCRIPTION
Re: https://github.com/bitcoin/bitcoin.org/pull/727 proposed by @ruimarinho 
- Ran `make manual-updates` to grab new summary
- Clarified that GHPS is part of 0.10.0 and is removed in master
- Autocrossref'd "Bitcoin Core master" to GitHub repo
- Removed GHPS from list of Mining RPCs now that it's in Removed RPCs
- Noted that the `gethashespersec` field is also removed from `getmininginfo`
